### PR TITLE
kie-server configuration now works with JBoss BRMS 6.2.0.GA. Fixes #9.

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -100,7 +100,7 @@ call set NOPAUSE=true
 echo.
 echo Applying JBoss EAP patch now...
 echo.
-call %JBOSS_HOME%/bin/jboss-cli.bat --command="patch apply %SRC_DIR%/%EAP_PATCH% --override-all"
+call %JBOSS_HOME%\bin\jboss-cli.bat --command="patch apply %SRC_DIR%/%EAP_PATCH% --override-all"
 
 if not "%ERRORLEVEL%" == "0" (
   echo.
@@ -118,6 +118,11 @@ if not "%ERRORLEVEL%" == "0" (
 	echo.
 	GOTO :EOF
 )
+
+echo "  - creating kie-server user..."
+echo.
+call %JBOSS_HOME%\bin\add-user.bat -a -r ApplicationRealm -u kieserver -p kieserver1! -ro kie-server --silent
+echo.
 
 echo - enabling demo accounts role setup in application-roles.properties file...
 echo.

--- a/init.sh
+++ b/init.sh
@@ -112,7 +112,12 @@ if [ $? -ne 0 ]; then
 	exit
 fi
 
+
 echo
+echo "  - creating kie-server user..."
+echo
+$JBOSS_HOME/bin/add-user.sh -a -r ApplicationRealm -u kieserver -p kieserver1! -ro kie-server --silent
+
 echo "  - enabling demo accounts role setup in application-roles.properties file..."
 echo
 cp $SUPPORT_DIR/application-roles.properties $SERVER_CONF

--- a/support/application-roles.properties
+++ b/support/application-roles.properties
@@ -35,3 +35,4 @@
 # * "manager" only be the dashboards
 #
 erics=analyst,admin,manager,user,kie-server,kiemgmt,rest-all
+kieserver=kie-server

--- a/support/standalone.xml
+++ b/support/standalone.xml
@@ -30,10 +30,17 @@
       <property name="org.kie.example" value="false"/>
       <property name="org.jbpm.designer.perspective" value="full"/>
       <property name="org.uberfire.nio.git.dir" value="${jboss.home.dir}/bin"/>
-			<property name="org.kie.server.repo" value="${jboss.server.data.dir}"/>
+      <property name="org.kie.server.repo" value="${jboss.server.data.dir}"/>
       <property name="org.uberfire.metadata.index.dir" value="${jboss.home.dir}/bin"/>
-			<property name="org.guvnor.m2repo.dir" value="${jboss.home.dir}/bin"/>
-   </system-properties>
+      <property name="org.guvnor.m2repo.dir" value="${jboss.home.dir}/bin"/>
+      <property name="org.kie.server.user" value="kieserver"></property>
+      <property name="org.kie.server.pwd" value="kieserver1!"></property>
+      <property name="org.kie.server.location" value="http://localhost:8080/kie-server/services/rest/server"></property>
+      <property name="org.kie.server.controller" value="http://localhost:8080/business-central/rest/controller"></property>
+      <property name="org.kie.server.controller.user" value="kieserver"></property>
+      <property name="org.kie.server.controller.pwd" value="kieserver1!"></property>
+      <property name="org.kie.server.id" value="local-server-123"></property>
+    </system-properties>
    <management>
       <security-realms>
          <security-realm name="ManagementRealm">


### PR DESCRIPTION
kie-server should now work again with JBoss BRMS 6.2.0.GA.
